### PR TITLE
Improve photo taking and selection behaviour

### DIFF
--- a/FileSelectionController/FileSelectionCollectionViewCell.xib
+++ b/FileSelectionController/FileSelectionCollectionViewCell.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>

--- a/FileSelectionController/FileSelectionView.xib
+++ b/FileSelectionController/FileSelectionView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
@@ -46,7 +46,7 @@
                                     </connections>
                                 </button>
                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="ExV-AX-iSN">
-                                    <rect key="frame" x="0.0" y="10" width="384" height="90"/>
+                                    <rect key="frame" x="0.0" y="10" width="384" height="100"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="100" id="1OO-i8-mV3"/>
@@ -63,10 +63,10 @@
                                     </connections>
                                 </collectionView>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3N7-DP-DHR">
-                                    <rect key="frame" x="0.0" y="110" width="384" height="40"/>
+                                    <rect key="frame" x="0.0" y="120" width="384" height="30"/>
                                     <color key="backgroundColor" red="0.29411764705882354" green="0.29411764705882354" blue="0.29411764705882354" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="40" id="mgj-G7-bXH"/>
+                                        <constraint firstAttribute="height" priority="999" constant="40" id="mgj-G7-bXH"/>
                                     </constraints>
                                     <state key="normal" title="Choose from Library">
                                         <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -84,7 +84,7 @@
                                     <rect key="frame" x="0.0" y="160" width="384" height="40"/>
                                     <color key="backgroundColor" red="0.29411764705882354" green="0.29411764705882354" blue="0.29411764705882354" alpha="1" colorSpace="calibratedRGB"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="40" id="ErC-yB-kVJ"/>
+                                        <constraint firstAttribute="height" priority="999" constant="40" id="ErC-yB-kVJ"/>
                                     </constraints>
                                     <state key="normal" title="Take a Photo">
                                         <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -121,9 +121,9 @@
                     </subviews>
                     <color key="backgroundColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
                     <constraints>
-                        <constraint firstItem="WHS-Z8-9ei" firstAttribute="leading" secondItem="iEn-Vu-Hgv" secondAttribute="leading" constant="15" id="5Ak-Ao-fXF"/>
+                        <constraint firstItem="WHS-Z8-9ei" firstAttribute="leading" secondItem="iEn-Vu-Hgv" secondAttribute="leading" priority="999" constant="15" id="5Ak-Ao-fXF"/>
                         <constraint firstItem="WHS-Z8-9ei" firstAttribute="top" secondItem="iEn-Vu-Hgv" secondAttribute="top" constant="15" id="Ihl-45-MrQ"/>
-                        <constraint firstAttribute="trailing" secondItem="WHS-Z8-9ei" secondAttribute="trailing" constant="15" id="Vbc-gs-vcP"/>
+                        <constraint firstAttribute="trailing" secondItem="WHS-Z8-9ei" secondAttribute="trailing" priority="999" constant="15" id="Vbc-gs-vcP"/>
                         <constraint firstAttribute="bottom" secondItem="WHS-Z8-9ei" secondAttribute="bottom" constant="15" id="fIU-Wo-Mxr"/>
                     </constraints>
                 </view>

--- a/FileSelectionController/FileSelectionView.xib
+++ b/FileSelectionController/FileSelectionView.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10089" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10072.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FileSelectionViewController" customModule="FileSelectionController" customModuleProvider="target">
@@ -86,7 +86,7 @@
                                     <constraints>
                                         <constraint firstAttribute="height" constant="40" id="ErC-yB-kVJ"/>
                                     </constraints>
-                                    <state key="normal" title="Take a Photo or Video">
+                                    <state key="normal" title="Take a Photo">
                                         <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     </state>
                                     <userDefinedRuntimeAttributes>

--- a/FileSelectionController/FileSelectionViewController.swift
+++ b/FileSelectionController/FileSelectionViewController.swift
@@ -68,10 +68,9 @@ public class FileSelectionViewController: UIViewController
     var recentlyAddedAssets: PHFetchResult?
     var singlePhotoSelectionAsset: PHFetchResult?
     
-    var imageManager = PHCachingImageManager()
+    var imageManager:PHCachingImageManager?
     var photoAlbumPlaceholder:PHObjectPlaceholder?
     var recentlyAddedPhotoLocalIdentifier: PHObjectPlaceholder?
-
     public var photoAlbumName: NSString?
     
     // Selection
@@ -115,6 +114,8 @@ public class FileSelectionViewController: UIViewController
         layout?.sectionInset = UIEdgeInsetsMake(0, 0, 0, 10)
         
         PHPhotoLibrary.sharedPhotoLibrary().registerChangeObserver(self);
+        
+        adjustOptions()
         
         // do we have access to the photos?
         if PHPhotoLibrary.authorizationStatus() != .Authorized
@@ -236,6 +237,12 @@ public class FileSelectionViewController: UIViewController
     
     private func loadPhotos ()
     {
+        guard PHPhotoLibrary.authorizationStatus() == .Authorized else { return }
+
+        if (imageManager == nil) {
+            imageManager = PHCachingImageManager()
+        }
+        
         let options = PHFetchOptions();
         options.fetchLimit = 100;
         
@@ -261,15 +268,15 @@ public class FileSelectionViewController: UIViewController
     
     public func present (multiple: Bool = false, completion: (([UIImage], NSError?) -> ())?) throws
     {
-        guard let window = UIApplication.sharedApplication().keyWindow, root = window.rootViewController else { throw FileSelectionViewControllerError.NoKeyWindow; }
+        guard let window = UIApplication.sharedApplication().keyWindow, root = window.rootViewController else { throw FileSelectionViewControllerError.NoKeyWindow
+        }
 
-        let presenter = root.presentedViewController ?? root;
-        self.completion = completion;
-        self.modalPresentationStyle = .OverFullScreen;
-        self.adjustOptions();
+        let presenter = root.presentedViewController ?? root
+        self.completion = completion
+        self.modalPresentationStyle = .OverFullScreen
         self.selectMultiple = multiple;
         self.modalPresentationCapturesStatusBarAppearance = true
-        presenter.presentViewController(self, animated: true, completion: nil);
+        presenter.presentViewController(self, animated: true, completion: nil)
     }
     
     public func hide ()
@@ -352,7 +359,7 @@ public class FileSelectionViewController: UIViewController
             
             if let asset = asset as? PHAsset
             {
-                self.imageManager.requestImageForAsset(asset, targetSize: PHImageManagerMaximumSize, contentMode: .AspectFill, options: nil)
+                self.imageManager?.requestImageForAsset(asset, targetSize: PHImageManagerMaximumSize, contentMode: .AspectFill, options: nil)
                 {
                     (image, info) in
                     if let image = image
@@ -543,7 +550,7 @@ extension FileSelectionViewController: UICollectionViewDataSource
         
         if let asset = asset as? PHAsset
         {
-            self.imageManager.requestImageForAsset(asset, targetSize: cell.frame.size, contentMode: .AspectFill, options: nil)
+            self.imageManager?.requestImageForAsset(asset, targetSize: cell.frame.size, contentMode: .AspectFill, options: nil)
             {
                 image, info in
                 cell.image = image;

--- a/FileSelectionController/FileSelectionViewController.swift
+++ b/FileSelectionController/FileSelectionViewController.swift
@@ -44,6 +44,16 @@ public class FileSelectionViewController: UIViewController
         }
     }
     
+    private var hideStatusBar: Bool = false
+    {
+        didSet(newValue)
+        {
+            if (newValue != hideStatusBar) {
+                self.setNeedsStatusBarAppearanceUpdate()
+            }
+        }
+    }
+    
     @IBOutlet var libraryButton: UIButton?
     @IBOutlet var photoButton: UIButton?
     @IBOutlet var stackView: UIStackView?
@@ -55,9 +65,14 @@ public class FileSelectionViewController: UIViewController
 
     let animationDuration = 0.34;
     
-    // Photos
-    var assets: PHFetchResult?
+    var recentlyAddedAssets: PHFetchResult?
+    var singlePhotoSelectionAsset: PHFetchResult?
+    
     var imageManager = PHCachingImageManager()
+    var photoAlbumPlaceholder:PHObjectPlaceholder?
+    var recentlyAddedPhotoLocalIdentifier: PHObjectPlaceholder?
+
+    public var photoAlbumName: NSString?
     
     // Selection
     var selectionOrder: [NSIndexPath] = []
@@ -94,8 +109,11 @@ public class FileSelectionViewController: UIViewController
         guard let collection = self.collectionView else { return; }
         
         collection.allowsMultipleSelection = self.selectMultiple;
-        
         collection.registerNib(FileSelectionCollectionViewCell.nib, forCellWithReuseIdentifier: FileSelectionCollectionViewCell.reuseIdentifier);
+
+        let layout = collection.collectionViewLayout as? UICollectionViewFlowLayout
+        layout?.sectionInset = UIEdgeInsetsMake(0, 0, 0, 10)
+        
         PHPhotoLibrary.sharedPhotoLibrary().registerChangeObserver(self);
         
         // do we have access to the photos?
@@ -113,11 +131,18 @@ public class FileSelectionViewController: UIViewController
                     }
                 }
             }
-
         } else
         {
             self.loadPhotos();
         }
+    }
+    
+    public override func preferredStatusBarUpdateAnimation() -> UIStatusBarAnimation {
+        return .Fade
+    }
+    
+    public override func prefersStatusBarHidden() -> Bool {
+        return hideStatusBar
     }
     
     private func hideCollectionView (animated: Bool, completion: ((Bool) -> ())?)
@@ -218,7 +243,7 @@ public class FileSelectionViewController: UIViewController
         let recent = PHAssetCollection.fetchAssetCollectionsWithType(.SmartAlbum, subtype: .SmartAlbumRecentlyAdded, options: options);
 
         options.sortDescriptors = [ NSSortDescriptor(key: "creationDate", ascending: false) ];
-        self.assets = PHAsset.fetchAssetsInAssetCollection(recent[0] as! PHAssetCollection, options: options);
+        self.recentlyAddedAssets = PHAsset.fetchAssetsInAssetCollection(recent[0] as! PHAssetCollection, options: options);
         self.collectionView?.reloadData();
 
         // if it is hidden we need to show it
@@ -243,6 +268,7 @@ public class FileSelectionViewController: UIViewController
         self.modalPresentationStyle = .OverFullScreen;
         self.adjustOptions();
         self.selectMultiple = multiple;
+        self.modalPresentationCapturesStatusBarAppearance = true
         presenter.presentViewController(self, animated: true, completion: nil);
     }
     
@@ -272,7 +298,6 @@ public class FileSelectionViewController: UIViewController
         }
     }
     
-    
     @IBAction func chooseFromLibraryButtonPressed(sender: UIButton)
     {
         let controller = UIImagePickerController();
@@ -283,10 +308,13 @@ public class FileSelectionViewController: UIViewController
  
     @IBAction func takePhotoButtonPressed(sender: UIButton)
     {
-        let controller = UIImagePickerController();
-        controller.sourceType = .Camera;
-        controller.delegate = self;
-        self.presentViewController(controller, animated: true, completion: nil);
+        hideStatusBar = true
+        
+        let controller = UIImagePickerController()
+        controller.sourceType = .Camera
+        controller.modalPresentationStyle = .FullScreen
+        controller.delegate = self
+        self.presentViewController(controller, animated: true, completion: nil)
     }
 
     @IBAction func cancelButtonPressed(sender: UIButton)
@@ -312,7 +340,17 @@ public class FileSelectionViewController: UIViewController
         self.selectionOrder.forEach
         {
             path in
-            if let asset = self.assets?[path.row] as? PHAsset
+            
+            var asset: AnyObject?
+            
+            switch path.section {
+            case 0:
+                asset = self.singlePhotoSelectionAsset?[path.row]
+            default:
+                asset = self.recentlyAddedAssets?[path.row]
+            }
+            
+            if let asset = asset as? PHAsset
             {
                 self.imageManager.requestImageForAsset(asset, targetSize: PHImageManagerMaximumSize, contentMode: .AspectFill, options: nil)
                 {
@@ -330,7 +368,6 @@ public class FileSelectionViewController: UIViewController
             }
         }
     }
-    
 }
 
 public enum FileSelectionViewControllerError: ErrorType
@@ -342,25 +379,132 @@ public enum FileSelectionViewControllerError: ErrorType
 
 extension FileSelectionViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate
 {
-    public func imagePickerController(picker: UIImagePickerController, didFinishPickingImage image: UIImage, editingInfo: [String : AnyObject]?)
+    public func imagePickerController(picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : AnyObject]?)
     {
-        self.presentingViewController?.dismissViewControllerAnimated(true)
+        if let info = info, let image = info[UIImagePickerControllerOriginalImage] as? UIImage
         {
-            if let completion = self.completion
+            // there's a case below where we've reset the list of assets to a single image.
+            // The main case of .Camera or a recent photo selection requires the original recent photos
+            // so we're going to get those back here. There's probably another way to do this, and that's
+            // store the results as different intance variables.
+            
+            // if we've come from the camera, 
+            if (picker.sourceType == .Camera)
             {
-                completion([image], nil);
+                self.saveImage(image)
+
+                self.hideStatusBar = false
+                picker.dismissViewControllerAnimated(true) {}
+            }
+            else
+            {
+                // you picked an image from the camera roll, you didn't take it just then
+                let url = info[UIImagePickerControllerReferenceURL] as! NSURL
+                let result = PHAsset.fetchAssetsWithALAssetURLs([url], options: nil)
+                if let photoObject = result.firstObject as? PHAsset {
+                    
+                    if let assets = self.recentlyAddedAssets {
+                        let idx = assets.indexOfObject(photoObject)
+                        
+                        // if the image is in the list we already have, select it
+                        if idx != NSNotFound {
+                            
+                            // clear collection view collection (lazy way)
+                            collectionView?.reloadData();
+                            self.clearSelectionOrder();
+                            
+                            let indexPath = NSIndexPath(forItem: idx, inSection: 1)
+                            self.addToSelectionOrder(indexPath)
+                            
+                            self.hideStatusBar = false
+                            picker.dismissViewControllerAnimated(true) {
+                                self.collectionView?.selectItemAtIndexPath(indexPath, animated: true, scrollPosition: .CenteredHorizontally)
+                            }
+                        } else {
+                            //photo not available, lets just replace the photos and select it.
+                            self.singlePhotoSelectionAsset = result
+
+                            collectionView?.reloadData();
+                            self.clearSelectionOrder();
+                            
+                            let indexPath = NSIndexPath(forItem: 0, inSection: 0)
+                            self.addToSelectionOrder(indexPath)
+                            self.collectionView?.selectItemAtIndexPath(indexPath, animated: true, scrollPosition: .Left)
+                            picker.dismissViewControllerAnimated(true) {}
+                        }
+                    }
+                }
             }
         }
     }
     
     public func imagePickerControllerDidCancel(picker: UIImagePickerController)
     {
-        self.presentingViewController?.dismissViewControllerAnimated(true)
+        self.hideStatusBar = false
+        picker.dismissViewControllerAnimated(true) {}
+    }
+}
+
+extension FileSelectionViewController
+{
+    private func fetchPhotoAlbum(completion:(assetCollection: PHAssetCollection?) -> ())
+    {
+        guard let albumName = self.photoAlbumName else {
+            completion(assetCollection: nil)
+            return
+        }
+        
+        let fetchOptions = PHFetchOptions()
+        fetchOptions.predicate = NSPredicate(format: "title = %@", albumName)
+        let collection : PHFetchResult = PHAssetCollection.fetchAssetCollectionsWithType(.Album, subtype: .Any, options: fetchOptions)
+        
+        if let firstObj = collection.firstObject as! PHAssetCollection?
         {
-            if let completion = self.completion
-            {
-                completion([], nil);
-            }
+            completion(assetCollection: firstObj)
+        }
+        else
+        {
+            PHPhotoLibrary.sharedPhotoLibrary().performChanges({
+                var createAlbumRequest : PHAssetCollectionChangeRequest = PHAssetCollectionChangeRequest.creationRequestForAssetCollectionWithTitle(albumName as String)
+                self.photoAlbumPlaceholder = createAlbumRequest.placeholderForCreatedAssetCollection
+                
+                }, completionHandler: { success, error in
+                    dispatch_async(dispatch_get_main_queue(), {
+                        if (success)
+                        {
+                            var collectionFetchResult = PHAssetCollection.fetchAssetCollectionsWithLocalIdentifiers([self.photoAlbumPlaceholder!.localIdentifier], options: nil)
+                            completion(assetCollection:collectionFetchResult.firstObject as! PHAssetCollection?)
+                        }
+                        else
+                        {
+                            completion(assetCollection: nil)
+                        }
+                    });
+            })
+        }
+    }
+    
+    private func saveImage(image: UIImage)
+    {
+        // try and sav it in the album we have created
+        fetchPhotoAlbum(){ assetCollection in
+            PHPhotoLibrary.sharedPhotoLibrary().performChanges({
+
+                let createAssetRequest = PHAssetChangeRequest.creationRequestForAssetFromImage(image)
+                let assetPlaceholder = createAssetRequest.placeholderForCreatedAsset
+                dispatch_async(dispatch_get_main_queue(), { 
+                    self.recentlyAddedPhotoLocalIdentifier = assetPlaceholder
+                })
+                if let assetCollection = assetCollection, let assetPlaceholder = assetPlaceholder
+                {
+                    let albumChangeRequest = PHAssetCollectionChangeRequest(forAssetCollection: assetCollection)!
+                    albumChangeRequest.addAssets([assetPlaceholder])
+                }
+                }, completionHandler: { success, error in
+//                    dispatch_async(dispatch_get_main_queue(), { 
+//                        print("SaveImage completion", success, error)
+//                    });
+            })
         }
     }
 }
@@ -371,22 +515,37 @@ extension FileSelectionViewController: UICollectionViewDataSource
 {
     public func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int
     {
-        return 1;
+        return 2;
     }
     
     public func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int
     {
-        return self.assets?.count ?? 0;
+        switch section {
+        case 0:
+            return self.singlePhotoSelectionAsset?.count ?? 0
+        default:
+            return self.recentlyAddedAssets?.count ?? 0
+        }
     }
     
     public func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell
     {
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier(FileSelectionCollectionViewCell.reuseIdentifier, forIndexPath: indexPath) as! FileSelectionCollectionViewCell;
-        if let asset = self.assets?[indexPath.row] as? PHAsset
+        
+        var asset:AnyObject?
+        
+        switch indexPath.section {
+        case 0:
+            asset = self.singlePhotoSelectionAsset?[indexPath.row]
+        default:
+            asset = self.recentlyAddedAssets?[indexPath.row]
+        }
+        
+        if let asset = asset as? PHAsset
         {
             self.imageManager.requestImageForAsset(asset, targetSize: cell.frame.size, contentMode: .AspectFill, options: nil)
             {
-                (image, info) in
+                image, info in
                 cell.image = image;
                 if let order = self.selectionOrder.indexOf(indexPath)
                 {
@@ -408,59 +567,12 @@ extension FileSelectionViewController: UICollectionViewDelegate
 {
     public func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath)
     {
-        
-        guard collectionView.allowsMultipleSelection == false else
-        {
-            let shouldShow = self.selectionOrder.count == 0;
-            self.selectionOrder.append(indexPath);
-            self.updateSelectionOrder();
-            if shouldShow
-            {
-                self.showUploadButton(true);
-            }
-            return;
-        }
-        
-        if let completion = self.completion, asset = self.assets?[indexPath.row] as? PHAsset
-        {
-            self.imageManager.requestImageForAsset(asset, targetSize: PHImageManagerMaximumSize, contentMode: .AspectFill, options: nil)
-            {
-                (image, info) in
-                self.presentingViewController?.dismissViewControllerAnimated(true)
-                {
-                    if let i = image
-                    {
-                        completion([i], nil);
-                    } else
-                    {
-                        completion([], nil);
-                    }
-                }
-            }
-        } else
-        {
-            self.presentingViewController?.dismissViewControllerAnimated(true)
-            {
-                if let completion = self.completion
-                {
-                    completion([], nil);
-                }
-            }
-        }
+        self.addToSelectionOrder(indexPath)
     }
     
     public func collectionView(collectionView: UICollectionView, didDeselectItemAtIndexPath indexPath: NSIndexPath)
     {
-        if let index = self.selectionOrder.indexOf(indexPath)
-        {
-            self.selectionOrder.removeAtIndex(index);
-            self.updateSelectionOrder();
-            
-            if self.selectionOrder.count == 0
-            {
-                self.hideUploadButton(true);
-            }
-        }
+        self.removeFromSelectionOrder(indexPath)
     }
     
     func updateSelectionOrder ()
@@ -473,6 +585,40 @@ extension FileSelectionViewController: UICollectionViewDelegate
             (self.collectionView?.cellForItemAtIndexPath(path) as? FileSelectionCollectionViewCell)?.selectedOrder = index
         }
     }
+    
+    private func removeFromSelectionOrder(indexPath: NSIndexPath)
+    {
+        if let index = self.selectionOrder.indexOf(indexPath)
+        {
+            self.selectionOrder.removeAtIndex(index);
+            self.updateSelectionOrder();
+            if self.selectionOrder.count == 0
+            {
+                self.hideUploadButton(true);
+            }
+        }
+    }
+    
+    private func addToSelectionOrder(indexPath: NSIndexPath)
+    {
+        let shouldShow = self.selectionOrder.count == 0;
+        
+        if self.selectionOrder.indexOf(indexPath) == nil
+        {
+            self.selectionOrder.append(indexPath)
+            self.updateSelectionOrder();
+            if shouldShow
+            {
+                self.showUploadButton(true);
+            }
+        }
+    }
+    
+    private func clearSelectionOrder()
+    {
+        self.selectionOrder.removeAll()
+        self.hideUploadButton(false);
+    }
 }
 
 // MARK: - PHPhotoLibraryChangeObserver
@@ -483,12 +629,80 @@ extension FileSelectionViewController: PHPhotoLibraryChangeObserver
     {
         dispatch_async(dispatch_get_main_queue())
         {
-            // did it change?
-            guard let assets = self.assets, collection = self.collectionView else { return };
+            guard let assets = self.recentlyAddedAssets, collection = self.collectionView else { return };
             if let details = changeInstance.changeDetailsForFetchResult(assets)
             {
-                self.assets = details.fetchResultAfterChanges;
-                collection.reloadData();
+                self.recentlyAddedAssets = details.fetchResultAfterChanges;
+
+                guard details.hasIncrementalChanges else {
+                    self.clearSelectionOrder();
+                    collection.reloadData();
+                    return
+                }
+                
+                if let removed = details.removedIndexes {
+                    let indexPaths = removed.map { NSIndexPath(forRow: $0, inSection: 1) };
+                    indexPaths.map(self.removeFromSelectionOrder)
+                    collection.deleteItemsAtIndexPaths(indexPaths)
+                }
+                
+                if let added = details.insertedIndexes {
+                    if let selectedIndexes = collection.indexPathsForSelectedItems() {
+                        selectedIndexes.map(self.removeFromSelectionOrder)
+                    }
+                    
+                    collection.insertItemsAtIndexPaths(added.map { NSIndexPath(forRow: $0, inSection: 1)})
+                    
+                    if let selectedIndexes = collection.indexPathsForSelectedItems() {
+                        selectedIndexes.map(self.addToSelectionOrder)
+                    }
+                }
+                
+                if let changed = details.changedIndexes {
+                    let selectedIndexes = collection.indexPathsForSelectedItems()
+                    collection.reloadItemsAtIndexPaths(changed.map { NSIndexPath(forRow: $0, inSection: 1)})
+                    
+                    // Reselect afer refresh. No need to add/remove from selectionOrder, indexes wont change
+                    if let selectedIndexes = selectedIndexes {
+                        for index in selectedIndexes {
+                            collection.selectItemAtIndexPath(index, animated: false, scrollPosition: .None)
+                        }
+                    }
+                }
+                
+                details.enumerateMovesWithBlock { from, to in
+                    if let selectedIndexes = collection.indexPathsForSelectedItems() {
+                        selectedIndexes.map(self.removeFromSelectionOrder)
+                    }
+                    collection.moveItemAtIndexPath(NSIndexPath(forRow: from, inSection: 1), toIndexPath: NSIndexPath(forRow: to, inSection: 1))
+                    
+                    if let selectedIndexes = collection.indexPathsForSelectedItems() {
+                        selectedIndexes.map(self.addToSelectionOrder)
+                    }
+                }
+                
+                // If we have a recently added image from the camera we iterate over the assets from fetchResultAfterChanges
+                // and attempt to select it in the collectionView.
+                if let newImage = self.recentlyAddedPhotoLocalIdentifier {
+                    if let selectedIndexes = collection.indexPathsForSelectedItems() {
+                        for indexPath in selectedIndexes {
+                            collection.deselectItemAtIndexPath(indexPath, animated: false)
+                            self.removeFromSelectionOrder(indexPath)
+                        }
+                    }
+
+                    assets.enumerateObjectsUsingBlock() { obj, index, stop in
+                        guard let obj = obj as? PHObject else { return }
+                        if obj.localIdentifier == newImage.localIdentifier {
+                            self.recentlyAddedPhotoLocalIdentifier = nil
+                            stop.memory = true
+                            
+                            let indexPath = NSIndexPath(forRow: index, inSection: 1)
+                            collection.selectItemAtIndexPath(indexPath, animated: true, scrollPosition: .CenteredHorizontally)
+                            self.addToSelectionOrder(indexPath)
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
New features:

Taking and selecting photos no longer automatically dismiss the modal and call the completion handler.

Selecting a photo from the library selects the relevant photo in the collection view if it's there, or makes it appear as the first item and selects it.

Taking a photo saves the photo to the camera roll and the subsequent update to the photo library is handled and the collection view is updated.

New photos will optinoally be saved in an album. The name of the album is configurable.

New photos or selected photos from library are automatically selected and previous selection is discarded.

Bug fixes
- Status bar is hidden before opening camera utilising modalPresentationCapturesStatusBarAppearance

Known issues
- Small gap on the left hand side of collection view due to secion 0 being empty and using sectionInset on the collection view layout
